### PR TITLE
Make the wine-mono folder for any version

### DIFF
--- a/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
@@ -646,11 +646,12 @@ modules:
     buildsystem: simple
     build-commands:
       - mkdir -p ${FLATPAK_DEST}/share/wine/mono
-      - cp -a . ${FLATPAK_DEST}/share/wine/mono/wine-mono-6.1.2
+      - cp -a wine-mono-*/ ${FLATPAK_DEST}/share/wine/mono/
     sources:
       - type: archive
         url: https://github.com/madewokherd/wine-mono/releases/download/wine-mono-6.4.1/wine-mono-6.4.1-x86.tar.xz
         sha256: a70c865e590058fa6fc3aa47425646405bdda27f78b9aa6d2030d2d2a8efadbb
+        strip-components: 0
 
 
   - name: wine-gecko-bin


### PR DESCRIPTION
When attempting to run a game with Proton-Exp community edition, an error is shown which says that a compatible wine-mono package couldn't be found.
I changed the folder name in my installation to 'wine-mono-6.4.1' and it worked after that.

This PR just copies what's already done in the stable Proton flatpak manifest.