### PR TITLE
fix(wine-mono): update to 7.2.0

### DIFF
--- a/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
@@ -588,8 +588,8 @@ modules:
       - cp -a wine-mono-*/ ${FLATPAK_DEST}/share/wine/mono/
     sources:
       - type: archive
-        url: https://github.com/madewokherd/wine-mono/releases/download/wine-mono-7.1.2/wine-mono-7.1.2-x86.tar.xz
-        sha256: 59f146dde0f0540ca4648fc648e6b16335c71921deaf111b5fe8c3967881661d
+        url: https://github.com/madewokherd/wine-mono/releases/download/wine-mono-7.2.0/wine-mono-7.2.0-x86.tar.xz
+        sha256: 25a4d08fee9197be83307e65553da450b6d4446cc9188d0a85212cc2cee2660d
         strip-components: 0
 
 


### PR DESCRIPTION
That's the wine mono version expected by the current Proton-Exp version (see https://github.com/ValveSoftware/Proton/blob/experimental-7.0-20220427c/Makefile.in#L199).

Will prevent the pop up to install wine mono to appear on each launch.