### PR TITLE
Fix flatpak install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This unofficial build isn't supported by Valve and wasn't tested with all possib
 
 First [add](https://flatpak.org/setup) Flathub repository and install Steam from there, if not already. Then run
 ```
-flatpak install com.valvesoftware.Steam.CompatibilityTool.Proton
+flatpak install com.valvesoftware.Steam.CompatibilityTool.Proton-Exp
 ```
 
 ## Running


### PR DESCRIPTION
The command should install Proton Experimental instead of the regular build.